### PR TITLE
Fix song promote (fixes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `!song promote` now moves the promoted song to the front of the queue instead of swapping positions with the first song in the queue. ([#30])
+
 ### Added
 - Import/Export for PhantomBot points.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Import/Export for PhantomBot points.
 
 [Unreleased]: https://github.com/udoprog/setmod/compare/0.2.4...HEAD
+[#30]: https://github.com/udoprog/setmod/issues/30
 
 ## [0.2.5]
 

--- a/bot/src/player.rs
+++ b/bot/src/player.rs
@@ -1142,7 +1142,9 @@ impl Queue {
             return None;
         }
 
-        q.swap(0, n);
+        if let Some(removed) = q.remove(n) {
+            q.push_front(removed);
+        }
 
         if let Some(item) = q.get(0).cloned() {
             self.db.promote_song_log(user, &item.track_id);


### PR DESCRIPTION
Updated player.rs to move songs to front of queue instead of swapping.